### PR TITLE
fix: forward include_first/include_last args in bizdays_between()

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,10 @@
+# mcrutils (development version)
+
+## Bug fixes
+- `bizdays_between()`: `include_first` and `include_last` arguments were
+    ignored and always treated as `TRUE`. They are now forwarded correctly to
+    `qlcal::businessDaysBetween()`.
+
 # mcrutils 0.0.0.9011
 
 ## New

--- a/R/bizdays_between.R
+++ b/R/bizdays_between.R
@@ -22,7 +22,7 @@ bizdays_between <- function(from, to, calendar,
   local_calendar(calendar)
 
   qlcal::businessDaysBetween(from, to,
-    includeFirst = TRUE,
-    includeLast = TRUE
+    includeFirst = include_first,
+    includeLast = include_last
   )
 }

--- a/tests/testthat/test-bizdays_between.R
+++ b/tests/testthat/test-bizdays_between.R
@@ -26,3 +26,34 @@ test_that("bizdays_between() errors on bad calendar", {
     error = TRUE
   )
 })
+
+test_that("bizdays_between() respects include_first and include_last", {
+  # baseline: both endpoints included (default)
+  expect_equal(
+    bizdays_between("2025-07-01", "2025-07-15", "UnitedStates",
+      include_first = TRUE, include_last = TRUE
+    ),
+    10
+  )
+  # exclude first only
+  expect_equal(
+    bizdays_between("2025-07-01", "2025-07-15", "UnitedStates",
+      include_first = FALSE, include_last = TRUE
+    ),
+    9
+  )
+  # exclude last only
+  expect_equal(
+    bizdays_between("2025-07-01", "2025-07-15", "UnitedStates",
+      include_first = TRUE, include_last = FALSE
+    ),
+    9
+  )
+  # exclude both endpoints
+  expect_equal(
+    bizdays_between("2025-07-01", "2025-07-15", "UnitedStates",
+      include_first = FALSE, include_last = FALSE
+    ),
+    8
+  )
+})


### PR DESCRIPTION
Previously both includeFirst and includeLast were hardcoded to TRUE in the qlcal::businessDaysBetween() call, making the user-facing arguments effectively ignored. This commit passes them through correctly and adds regression tests covering all four include_first/include_last combinations.