### PR TITLE
rename_cols_for_display(): minor-word-aware title casing

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -35,6 +35,7 @@ Imports:
     purrr,
     qlcal,
     rlang,
+    snakecase,
     stringr,
     tidyr,
     tidyselect,

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,12 @@
+# mcrutils (development version)
+
+## Behavior changes
+- `rename_cols_for_display()` now uses minor-word-aware title casing (via
+    `snakecase::to_title_case()`) instead of `stringr::str_to_title()`. Short
+    connecting words such as "of", "to", "per", and "vs" stay lowercase (e.g.
+    `new_to_market` -> "New to Market"). Acronym preservation via `all_caps`
+    is unchanged. Adds a dependency on `snakecase`.
+
 # mcrutils 0.0.0.9012
 
 ## Bug fixes

--- a/R/display_formatting.R
+++ b/R/display_formatting.R
@@ -1,7 +1,10 @@
 #' Rename columns for display
 #'
 #' Convert snake_case-like column names to title-style labels, optionally
-#' preserving selected acronyms in uppercase.
+#' preserving selected acronyms in uppercase. Title casing is minor-word aware
+#' (via [snakecase::to_title_case()]), so short connecting words such as "of",
+#' "to", "per", and "vs" stay lowercase (e.g. `new_to_market` becomes
+#' "New to Market").
 #'
 #' @param data A data frame or tibble.
 #' @param all_caps A character vector of tokens to preserve in uppercase.
@@ -22,10 +25,7 @@ rename_cols_for_display <- function(data, all_caps = character()) {
   }
 
   format_name <- function(x) {
-    label <- x |>
-      stringr::str_replace_all("[-._]+", " ") |>
-      stringr::str_squish() |>
-      stringr::str_to_title()
+    label <- snakecase::to_title_case(x)
 
     if (length(all_caps) == 0) {
       return(label)

--- a/man/rename_cols_for_display.Rd
+++ b/man/rename_cols_for_display.Rd
@@ -17,7 +17,10 @@ A data frame with renamed columns.
 }
 \description{
 Convert snake_case-like column names to title-style labels, optionally
-preserving selected acronyms in uppercase.
+preserving selected acronyms in uppercase. Title casing is minor-word aware
+(via \code{\link[snakecase:caseconverter]{snakecase::to_title_case()}}), so short connecting words such as "of",
+"to", "per", and "vs" stay lowercase (e.g. \code{new_to_market} becomes
+"New to Market").
 }
 \examples{
 data.frame(volume_py = 1, abc_units = 2) |>

--- a/tests/testthat/test-rename_cols_for_display.R
+++ b/tests/testthat/test-rename_cols_for_display.R
@@ -37,6 +37,22 @@ test_that("rename_cols_for_display works with tibbles", {
   expect_equal(names(result), c("Order Date", "YTD Value"))
 })
 
+test_that("rename_cols_for_display keeps minor words lowercase", {
+  x <- data.frame(
+    new_to_market = 1,
+    share_of_us = 2,
+    cost_per_unit = 3,
+    check.names = FALSE
+  )
+
+  result <- rename_cols_for_display(x, all_caps = "US")
+
+  expect_equal(
+    names(result),
+    c("New to Market", "Share of US", "Cost per Unit")
+  )
+})
+
 test_that("rename_cols_for_display validates all_caps input", {
   x <- data.frame(value = 1)
 


### PR DESCRIPTION
Use `snakecase::to_title_case()` instead of `stringr::str_to_title()` so short connecting words (of, to, per, vs, ...) stay lowercase, e.g. `new_to_market` -> "New to Market". Acronym preservation via `all_caps` is unchanged.

Adds `snakecase` to Imports. NEWS is under (development version); the version bump to 0.0.0.9013 happens on master after merge.

Note: this is a behavior change for any consumer that renders multi-word column labels.
